### PR TITLE
Fix inputRead function in DEGpattern.Rmd

### DIFF
--- a/04_gene_patterns/DEGpattern.Rmd
+++ b/04_gene_patterns/DEGpattern.Rmd
@@ -79,10 +79,10 @@ opts_chunk[["set"]](
 invisible(list2env(params, environment()))
 
 inputRead <- function(f) {
-  if (isUrl(deseq_obj)) {
-    return(readRDS(url(deseq_obj)))
+  if (R.utils::isUrl(f)) {
+    return(readRDS(url(f)))
   } else {
-    return(readRDS(deseq_obj))
+    return(readRDS(f))
   }
 }
 ```


### PR DESCRIPTION
- Specify `R.utils::isUrl` to avoid error: could not find function "isUrl"
- Change loaded file name object from "deseq_obj" (specifically the DESeqDataSet) to "f" (input to function)