### PR TITLE
use better code to publish in ghpages

### DIFF
--- a/.github/workflows/run_deg.yml
+++ b/.github/workflows/run_deg.yml
@@ -63,9 +63,20 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin gh-pages || git checkout --orphan gh-pages
-          git switch gh-pages || git checkout -b gh-pages
-          git add 02_differential_expression/differential_expression.html
-          git commit -m "Deploy differential_expression.html [skip ci]" || echo "No changes to commit"
-          git push origin gh-pages
+          OUTPUT_FILE="02_differential_expression/differential_expression.html"
+
+          # Fetch gh-pages (if exists) and create worktree
+          git fetch origin gh-pages || true
+          git worktree add /tmp/gh-pages gh-pages 2>/dev/null || git worktree add /tmp/gh-pages -b gh-pages
+
+          # Copy the file into the worktree
+          mkdir -p "/tmp/gh-pages/$(dirname "$OUTPUT_FILE")"
+          cp "$OUTPUT_FILE" "/tmp/gh-pages/$(dirname "$OUTPUT_FILE")/"
+
+          cd /tmp/gh-pages
+
+          # Commit and push if there are changes
+          git add "$(dirname "$OUTPUT_FILE")/$(basename "$OUTPUT_FILE")"
+          git commit -m "Deploy $(basename "$OUTPUT_FILE") [skip ci]"
+          git push --force origin gh-pages
         shell: bash

--- a/.github/workflows/run_degpattern.yml
+++ b/.github/workflows/run_degpattern.yml
@@ -63,9 +63,20 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin gh-pages || git checkout --orphan gh-pages
-          git switch gh-pages || git checkout -b gh-pages
-          git add 04_gene_patterns/DEGpattern.html
-          git commit -m "Deploy DEGpattern.html [skip ci]" || echo "No changes to commit"
-          git push origin gh-pages
+          OUTPUT_FILE="04_gene_patterns/DEGpattern.html"
+
+          # Fetch gh-pages (if exists) and create worktree
+          git fetch origin gh-pages || true
+          git worktree add /tmp/gh-pages gh-pages 2>/dev/null || git worktree add /tmp/gh-pages -b gh-pages
+
+          # Copy the file into the worktree
+          mkdir -p "/tmp/gh-pages/$(dirname "$OUTPUT_FILE")"
+          cp "$OUTPUT_FILE" "/tmp/gh-pages/$(dirname "$OUTPUT_FILE")/"
+
+          cd /tmp/gh-pages
+
+          # Commit and push if there are changes
+          git add "$(dirname "$OUTPUT_FILE")/$(basename "$OUTPUT_FILE")"
+          git commit -m "Deploy $(basename "$OUTPUT_FILE") [skip ci]"
+          git push --force origin gh-pages
         shell: bash

--- a/.github/workflows/run_qc.yml
+++ b/.github/workflows/run_qc.yml
@@ -66,9 +66,20 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin gh-pages || git checkout --orphan gh-pages
-          git switch gh-pages || git checkout -b gh-pages
-          git add 01_quality_assessment/quality_assessment.html
-          git commit -m "Deploy quality_assessment.html [skip ci]" || echo "No changes to commit"
-          git push origin gh-pages
+          OUTPUT_FILE="01_quality_assessment/quality_assessment.html"
+
+          # Fetch gh-pages (if exists) and create worktree
+          git fetch origin gh-pages || true
+          git worktree add /tmp/gh-pages gh-pages 2>/dev/null || git worktree add /tmp/gh-pages -b gh-pages
+
+          # Copy the file into the worktree
+          mkdir -p "/tmp/gh-pages/$(dirname "$OUTPUT_FILE")"
+          cp "$OUTPUT_FILE" "/tmp/gh-pages/$(dirname "$OUTPUT_FILE")/"
+
+          cd /tmp/gh-pages
+
+          # Commit and push if there are changes
+          git add "$(dirname "$OUTPUT_FILE")/$(basename "$OUTPUT_FILE")"
+          git commit -m "Deploy $(basename "$OUTPUT_FILE") [skip ci]"
+          git push --force origin gh-pages
         shell: bash

--- a/.github/workflows/run_wgcna.yml
+++ b/.github/workflows/run_wgcna.yml
@@ -63,9 +63,20 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin gh-pages || git checkout --orphan gh-pages
-          git switch gh-pages || git checkout -b gh-pages
-          git add 04_gene_patterns/WGCNA.html
-          git commit -m "Deploy WGCNA.html [skip ci]" || echo "No changes to commit"
-          git push origin gh-pages
+          OUTPUT_FILE="04_gene_patterns/WGCNA.html"
+
+          # Fetch gh-pages (if exists) and create worktree
+          git fetch origin gh-pages || true
+          git worktree add /tmp/gh-pages gh-pages 2>/dev/null || git worktree add /tmp/gh-pages -b gh-pages
+
+          # Copy the file into the worktree
+          mkdir -p "/tmp/gh-pages/$(dirname "$OUTPUT_FILE")"
+          cp "$OUTPUT_FILE" "/tmp/gh-pages/$(dirname "$OUTPUT_FILE")/"
+
+          cd /tmp/gh-pages
+
+          # Commit and push if there are changes
+          git add "$(dirname "$OUTPUT_FILE")/$(basename "$OUTPUT_FILE")"
+          git commit -m "Deploy $(basename "$OUTPUT_FILE") [skip ci]"
+          git push --force origin gh-pages
         shell: bash

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: ${{ github.head_ref }}
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v2


### PR DESCRIPTION
This pull request refactors the deployment steps in several GitHub Actions workflow files to use a safer and more robust approach for publishing HTML reports to the `gh-pages` branch. Instead of directly switching branches and overwriting files, the workflows now use Git worktrees to isolate deployment changes, reducing the risk of accidental overwrites and improving reliability. Additionally, the checkout step in the style workflow is updated for more precise control.

**Deployment workflow improvements:**

* Refactored deployment steps in `.github/workflows/run_deg.yml`, `.github/workflows/run_degpattern.yml`, `.github/workflows/run_qc.yml`, and `.github/workflows/run_wgcna.yml` to use Git worktrees for publishing HTML reports to `gh-pages`, ensuring safer and cleaner deployments. [[1]](diffhunk://#diff-512f4b40a7f5468e3b58dc8a37ab75c939e9220db3849ca022c3202d408ab7eeL66-R81) [[2]](diffhunk://#diff-95b639bbdec0866b784aca7727140c62f6ca16e39b372f0cc9ce79b448f3ef12L66-R81) [[3]](diffhunk://#diff-de7596f5cb022b886be1deeeb0f6780d63884547223ab5bc46cb3b1af8faedbcL69-R84) [[4]](diffhunk://#diff-e3c424afa5e0abf6cf785bd41ee07260ae6a71be2cb505ddc58063f2cfb9543fL66-R81)

**General workflow enhancements:**

* Updated the checkout step in `.github/workflows/style.yaml` to use the current head reference (`github.head_ref`) instead of `fetch-depth: 0`, providing more control over which commit is checked out during style checks.